### PR TITLE
INT-1763: Expanding numeric conversions

### DIFF
--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -12,6 +12,7 @@ const bson = require('bson');
 const MinKey = bson.MinKey;
 const MaxKey = bson.MaxKey;
 const Long = bson.Long;
+const Double = bson.Double;
 
 /**
  * The object string.
@@ -94,13 +95,21 @@ function toArray(object) {
   return [ object ];
 }
 
+function toLong(object) {
+  return new Long(toNumber(object));
+}
+
+function toDouble(object) {
+  return new Double(toNumber(object));
+}
+
 /**
  * The functions to cast to a type.
  */
 const CASTERS = {
   'Int32': toNumber,
-  'Int64': toNumber,
-  'Double': toNumber,
+  'Int64': toLong,
+  'Double': toDouble,
   'Date': toDate,
   'MinKey': toMinKey,
   'MaxKey': toMaxKey,
@@ -167,8 +176,8 @@ const DATE_CHECK = new DateCheck();
  */
 const STRING_TESTS = [
   new Test(/^$/, [ 'String', 'Null', 'Undefined', 'MinKey', 'MaxKey', 'Object', 'Array' ]),
-  new Test(INT32_CHECK, [ 'String', 'Int32', 'Object', 'Array' ]),
-  new Test(INT64_CHECK, [ 'String', 'Int64', 'Object', 'Array' ]),
+  new Test(INT32_CHECK, [ 'String', 'Int32', 'Int64', 'Double', 'Object', 'Array' ]),
+  new Test(INT64_CHECK, [ 'String', 'Int64', 'Double', 'Object', 'Array' ]),
   new Test(/^-?(\d*\.)?\d+$/, [ 'String', 'Double', 'Object', 'Array' ]),
   new Test(/^(null)$/, [ 'String', 'Null', 'Object', 'Array' ]),
   new Test(/^(undefined)$/, [ 'String', 'Undefined', 'Object', 'Array' ]),

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -9,6 +9,8 @@ const Binary = bson.Binary;
 const BSONRegExp = bson.BSONRegExp;
 const Code = bson.Code;
 const Timestamp = bson.Timestamp;
+const Long = bson.Long;
+const Double = bson.Double;
 const TypeChecker = require('../lib/type-checker');
 
 describe('TypeChecker', function() {
@@ -44,11 +46,11 @@ describe('TypeChecker', function() {
         });
 
         context('when the integer is 64 bit', function() {
-          context('when casting to an int32', function() {
+          context('when casting to an int64', function() {
             var value = '2147483648';
 
-            it('returns the number', function() {
-              expect(TypeChecker.cast(value, 'Int64')).to.equal(2147483648);
+            it('returns the int64', function() {
+              expect(TypeChecker.cast(value, 'Int64')).to.deep.equal(new Long(2147483648));
             });
           });
         });
@@ -59,7 +61,7 @@ describe('TypeChecker', function() {
           var value = '23.45';
 
           it('returns the number', function() {
-            expect(TypeChecker.cast(value, 'Double')).to.equal(23.45);
+            expect(TypeChecker.cast(value, 'Double')).to.deep.equal(new Double(23.45));
           });
         });
       });
@@ -379,6 +381,8 @@ describe('TypeChecker', function() {
               expect(TypeChecker.castableTypes(value)).to.deep.equal([
                 'String',
                 'Int32',
+                'Int64',
+                'Double',
                 'Object',
                 'Array'
               ]);
@@ -392,6 +396,7 @@ describe('TypeChecker', function() {
               expect(TypeChecker.castableTypes(value)).to.deep.equal([
                 'String',
                 'Int64',
+                'Double',
                 'Object',
                 'Array'
               ]);

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -102,10 +102,58 @@ describe('TypeChecker', function() {
       });
     });
 
-    context('when the object is a double', function() {
+    context('when the object is a primitive double', function() {
       context('when casting to a string', function() {
         it('returns the number as a string', function() {
           expect(TypeChecker.cast(2.45, 'String')).to.equal('2.45');
+        });
+      });
+    });
+
+    context('when the object is a double', function() {
+      context('when casting to a string', function() {
+        it('returns the number as a string', function() {
+          expect(TypeChecker.cast(new Double(2.45), 'String')).to.equal('2.45');
+        });
+      });
+    });
+
+    context('when the object is a long', function() {
+      context('when casting to a string', function() {
+        it('returns the number as a string', function() {
+          expect(TypeChecker.cast(new Long(245), 'String')).to.equal('245');
+        });
+      });
+
+      context('when casting to an int32', function() {
+        it('returns the number as an int32', function() {
+          expect(TypeChecker.cast(new Long(245), 'Int32')).to.equal(245);
+        });
+      });
+
+      context('when casting to a double', function() {
+        it('returns the number as a double', function() {
+          expect(TypeChecker.cast(new Long(245), 'Double')).to.deep.equal(new Double(245));
+        });
+      });
+    });
+
+    context('when the object is an int32', function() {
+      context('when casting to a string', function() {
+        it('returns the number as a string', function() {
+          expect(TypeChecker.cast(245, 'String')).to.equal('245');
+        });
+      });
+
+      context('when casting to an int64', function() {
+        it('returns the number as an int64', function() {
+          expect(TypeChecker.cast(245, 'Int64')).to.deep.equal(new Long(245));
+        });
+      });
+
+      context('when casting to a double', function() {
+        it('returns the number as a double', function() {
+          expect(TypeChecker.cast(245, 'Double')).to.deep.equal(new Double(245));
         });
       });
     });


### PR DESCRIPTION
Allows the new conversions:

`Int32` -> `Int64`
`Int32` -> `Double`
`Int64` -> `Double`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/hadron-type-checker/2)
<!-- Reviewable:end -->
