### PR TITLE
Fix boolean casting when not string

### DIFF
--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -83,7 +83,13 @@ function toNull() {
 }
 
 function toBoolean(object) {
-  if (object.toLowerCase() === 'true') {
+  if (isString(object)) {
+    if (object.toLowerCase() === 'true') {
+      return true;
+    }
+    return false;
+  }
+  if (object) {
     return true;
   }
   return false;

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -45,6 +45,32 @@ describe('TypeChecker', function() {
               expect(TypeChecker.cast(value, 'Int32')).to.deep.equal(new Int32(23));
             });
           });
+
+          context('when casting to a boolean', function() {
+            context('when the int is 0', function() {
+              it('returns false', function() {
+                expect(TypeChecker.cast(0, 'Boolean')).to.equal(false);
+              });
+            });
+
+            context('when the int is 1', function() {
+              it('returns true', function() {
+                expect(TypeChecker.cast(1, 'Boolean')).to.equal(true);
+              });
+            });
+
+            context('when the int is > 1', function() {
+              it('returns true', function() {
+                expect(TypeChecker.cast(2, 'Boolean')).to.equal(true);
+              });
+            });
+
+            context('when the int is < 0', function() {
+              it('returns true', function() {
+                expect(TypeChecker.cast(-2, 'Boolean')).to.equal(true);
+              });
+            });
+          });
         });
 
         context('when the integer is 64 bit', function() {


### PR DESCRIPTION
Fixes "Uncaught TypeError: object.toLowerCase is not a function" when casting from integer to boolean.