### PR TITLE
Replace _.isArray with Array.isArray

### DIFF
--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const isPlainObject = require('lodash.isplainobject');
-const isArray = require('lodash.isarray');
 const isString = require('lodash.isstring');
 const isNumber = require('lodash.isnumber');
 const isEmpty = require('lodash.isempty');
@@ -104,7 +103,7 @@ function toObject(object) {
 }
 
 function toArray(object) {
-  if (isArray(object)) {
+  if (Array.isArray(object)) {
     return object;
   }
   if (isPlainObject(object)) {
@@ -350,7 +349,7 @@ class TypeChecker {
     if (isPlainObject(object)) {
       return OBJECT;
     }
-    if (isArray(object)) {
+    if (Array.isArray(object)) {
       return ARRAY;
     }
     if (has(object, BSON_TYPE)) {
@@ -383,7 +382,7 @@ class TypeChecker {
         return [ 'Object', 'Array' ];
       }
       return [ 'Object' ];
-    } else if (isArray(object)) {
+    } else if (Array.isArray(object)) {
       if (isEmpty(object)) {
         return [ 'Object', 'Array' ];
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "lodash.find": "^4.4.0",
     "lodash.has": "^4.4.0",
     "lodash.includes": "^4.3.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.isempty": "^4.0.0",
     "lodash.isnumber": "^3.0.3",
     "lodash.isplainobject": "^4.0.4",


### PR DESCRIPTION

https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray

This PR should resolve the following warning on first `npm install`:
> npm WARN deprecated lodash.isarray@4.0.0: This package is deprecated. Use Array.isArray.

i.e. after this PR, the following should no longer appear when `npm install`-ing in Compass:

<img width="489" alt="refactoring should resolve this" src="https://cloud.githubusercontent.com/assets/1217010/24282576/8651cfaa-10b4-11e7-8841-7965c4401192.png">
