### PR TITLE
COMPASS-919 Date handling

### DIFF
--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -366,7 +366,7 @@ class TypeChecker {
    * Get a list of types the object can be cast to.
    *
    * @param {Object} object - The object.
-   * @param {Boolean} highPrecisionSupport - If high precision is supported or not.
+   * @param {Boolean} highPrecisionSupport - If Decimal128 is supported or not.
    *
    * @returns {Array} The available types.
    */

--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -241,17 +241,12 @@ class Decimal128Check {
   }
 }
 
-const DATE_REGEX = /^(\d{4})-(\d|\d{2})-(\d|\d{2})(T\d{2}\:\d{2}\:\d{2}(\.\d+)?)?$/;
-
 /**
  * Checks if a string is a date.
  */
 class DateCheck {
   test(string) {
-    if (DATE_REGEX.test(string)) {
-      var date = Date.parse(string);
-      return date ? true : false;
-    }
+    return isFinite(toDate(string).getTime());
   }
 }
 

--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -258,7 +258,8 @@ const DECIMAL_128_CHECK = new Decimal128Check();
 const DATE_CHECK = new DateCheck();
 
 /**
- * The various string tests.
+ * The various string tests,
+ * excluding dates which are on their own dimension.
  */
 const STRING_TESTS = [
   new Test(/^$/, [ 'String', 'Null', 'MinKey', 'MaxKey', 'Object', 'Array', 'ObjectID']),
@@ -270,12 +271,12 @@ const STRING_TESTS = [
   new Test(/^(undefined)$/, [ 'Undefined', 'String', 'Object', 'Array' ]),
   new Test(/^(true|false)$/, [ 'Boolean', 'String', 'Object', 'Array' ]),
   new Test(/^\/(.*)\/$/, [ 'BSONRegExp', 'String', 'Object', 'Array' ]),
-  new Test(DATE_CHECK, [ 'Date', 'String', 'Object', 'Array' ]),
   new Test(/(^$)|^[A-Fa-f0-9]{24}$/, [ 'String', 'Object', 'Array', 'ObjectID' ])
 ];
 
 /**
- * String tests with high precision support.
+ * String tests with high precision support,
+ * excluding dates which are on their own dimension.
  */
 const HP_STRING_TESTS = [
   new Test(/^$/, [ 'String', 'Null', 'MinKey', 'MaxKey', 'Object', 'Array', 'ObjectID' ]),
@@ -288,7 +289,6 @@ const HP_STRING_TESTS = [
   new Test(/^(undefined)$/, [ 'Undefined', 'String', 'Object', 'Array' ]),
   new Test(/^(true|false)$/, [ 'Boolean', 'String', 'Object', 'Array' ]),
   new Test(/^\/(.*)\/$/, [ 'BSONRegExp', 'String', 'Object', 'Array' ]),
-  new Test(DATE_CHECK, [ 'Date', 'String', 'Object', 'Array' ]),
   new Test(/(^$)|^[A-Fa-f0-9]{24}$/, [ 'String', 'Object', 'Array', 'ObjectID' ])
 ];
 
@@ -393,10 +393,20 @@ class TypeChecker {
   }
 
   _stringTypes(string, highPrecisionSupport) {
+    let types = [ 'String', 'Object', 'Array' ];
     var passing = find(highPrecisionSupport ? HP_STRING_TESTS : STRING_TESTS, (test) => {
       return test.tester.test(string);
     });
-    return passing ? passing.types : [ 'String', 'Object', 'Array' ];
+    if (passing) {
+      types = passing.types;
+    }
+    // Add date dynamically to the existing types lists, as it is on a
+    // completely different dimension to numeric types and so significantly
+    // more complicated to enumerate all valid combinations
+    if (DATE_CHECK.test(string)) {
+      types = ['Date', ...types];
+    }
+    return types;
   }
 }
 

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -887,6 +887,69 @@ describe('TypeChecker', function() {
             });
           });
 
+          context('with ISO-8601 dates it handles', function() {
+            // Using https://www.w3.org/TR/NOTE-datetime
+            it('Year', () => {
+              const value = '1997';
+              expect(TypeChecker.castableTypes(value)).to.deep.equal([
+                'Date',
+                'String',
+                'Object',
+                'Array'
+              ]);
+            });
+
+            it('Year and month', () => {
+              const value = '1997-07';
+              expect(TypeChecker.castableTypes(value)).to.deep.equal([
+                'Date',
+                'String',
+                'Object',
+                'Array'
+              ]);
+            });
+
+            it('Complete date', () => {
+              const value = '1997-07-16';
+              expect(TypeChecker.castableTypes(value)).to.deep.equal([
+                'Date',
+                'String',
+                'Object',
+                'Array'
+              ]);
+            });
+
+            it('Complete date plus hours and minutes', () => {
+              const value = '1997-07-16T19:20+01:00';
+              expect(TypeChecker.castableTypes(value)).to.deep.equal([
+                'Date',
+                'String',
+                'Object',
+                'Array'
+              ]);
+            });
+
+            it('Complete date plus hours, minutes and seconds', () => {
+              const value = '1997-07-16T19:20:30+01:00';
+              expect(TypeChecker.castableTypes(value)).to.deep.equal([
+                'Date',
+                'String',
+                'Object',
+                'Array'
+              ]);
+            });
+
+            it('Complete date plus hours, minutes, seconds and a decimal fraction of a second', () => {
+              const value = '1997-07-16T19:20:30.45+01:00';
+              expect(TypeChecker.castableTypes(value)).to.deep.equal([
+                'Date',
+                'String',
+                'Object',
+                'Array'
+              ]);
+            });
+          });
+
           context('when the date is with time and decimal', function() {
             var value = '2016-10-10T12:12:00.001';
 

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -563,6 +563,7 @@ describe('TypeChecker', function() {
 
               it('returns the list', function() {
                 expect(TypeChecker.castableTypes(value, true)).to.deep.equal([
+                  'Date',
                   'Double',
                   'Decimal128',
                   'String',

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -963,8 +963,21 @@ describe('TypeChecker', function() {
             });
           });
 
-          context('when the date is invalid', function() {
-            var value = '2016-10-10 12:12:00.001';
+          context('when the date contains a space instead of a T', function() {
+            const value = '2016-10-10 12:12:00.001';
+
+            it('returns the list', function() {
+              expect(TypeChecker.castableTypes(value)).to.deep.equal([
+                'Date',
+                'String',
+                'Object',
+                'Array'
+              ]);
+            });
+          });
+
+          context('when the date is invalid no matter which way you interpret it', function() {
+            const value = '2016.13.13';  // There is no 13th month
 
             it('returns the list', function() {
               expect(TypeChecker.castableTypes(value)).to.deep.equal([

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -893,6 +893,9 @@ describe('TypeChecker', function() {
               const value = '1997';
               expect(TypeChecker.castableTypes(value)).to.deep.equal([
                 'Date',
+                'Int32',
+                'Int64',
+                'Double',
                 'String',
                 'Object',
                 'Array'

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -1412,16 +1412,18 @@ describe('TypeChecker', function() {
 
   describe('invalid Decimal-128 values', function() {
     context('invalid strings', function() {
-      var values = [
-        'E02',
+      const invalidDecimal128DateValues = [
         'E+02',
         'e+02',
+        '..1'
+      ];
+      const invalidDecimal128Values = [
+        'E02',
         '.',
         '.e',
         'invalid',
         'in',
         'i',
-        '..1',
         '1abcede',
         '1.24abc',
         '1.24abcE+02',
@@ -1430,25 +1432,33 @@ describe('TypeChecker', function() {
         '12324.123.1233',
         '123E 123'
       ];
-      for (var i = 0; i < values.length; i++) {
-        const value = values[i];
-        context(value + ' cast', function() {
-          it('cast throws an error', function() {
-            expect(function() {
-              TypeChecker.cast(value, 'Decimal128');
-            }).to.throw(value + ' not a valid Decimal128 string');
+      /**
+       * Build Decimal128 tests from a list of test values and
+       * a common array of expectations.
+       *
+       * @param {Array} values - Which values to apply this
+       * @param {Array} expectations -
+       */
+      const decimal128TestFactory = (values, expectations) => {
+        for (let i = 0; i < values.length; i++) {
+          const value = values[i];
+          context(value + ' cast', function() {
+            it('cast throws an error', function() {
+              expect(function() {
+                TypeChecker.cast(value, 'Decimal128');
+              }).to.throw(value + ' not a valid Decimal128 string');
+            });
           });
-        });
-        context(value + ' castableTypes', function() {
-          it('castableTypes does not include Decimal 128', function() {
-            expect(TypeChecker.castableTypes(value, true)).to.deep.equal(
-              ['String',
-                'Object',
-                'Array']
-            );
+          context(value + ' castableTypes', function() {
+            it('castableTypes does not include Decimal 128', function() {
+              expect(TypeChecker.castableTypes(value, true)).to.deep.equal(expectations);
+            });
           });
-        });
-      }
+        }
+      };
+      //
+      decimal128TestFactory(invalidDecimal128DateValues, ['Date', 'String', 'Object', 'Array']);
+      decimal128TestFactory(invalidDecimal128Values, ['String', 'Object', 'Array']);
     });
 
     context('empty string', function() {


### PR DESCRIPTION
This PR aims to do several things to improve date editing in Compass.

### Newly Working

1. Allow user-entry of more ISO-8601 strings based on https://www.w3.org/TR/NOTE-datetime

   ![compass-919-iso-8601-example](https://cloud.githubusercontent.com/assets/1217010/24234705/ce71b308-0fed-11e7-969a-e934584ea2b9.gif)

2. Allow all single character text replacements of an existing date:

   ![compass-919-select-replace-single-char](https://cloud.githubusercontent.com/assets/1217010/24234837/7db14798-0fee-11e7-9cf3-4312bcbaca6f.gif)

3. Allow adding an extra digit to the year then removing it (seems to be a special case).

### Still unresolved

It does not allow editing an existing date that would place it into an invalid state. For example:

1. Attempting to change `2017` to `2018` by first removing the `8` (using the backspace key):

    ![compass-919-cannot-delete-first](https://cloud.githubusercontent.com/assets/1217010/24235043/78833014-0fef-11e7-9b2c-71c98d50cf76.gif)

2. Attempting to change the month, day, hour, minute or second by **removing a non-zero digit and then replacing it with another one**, without needing to manually put the cursor back in the correct spot (might be fixed by COMPASS-921):

![compass-919-remove-can-lose-type](https://cloud.githubusercontent.com/assets/1217010/24235322/d7ee85ac-0ff0-11e7-98aa-abe16ff26697.gif)

3. Attempting to change the month, day, hour, minute or second by **adding a digit and then removing the redundant digit** (if both digits are already non-zero, without going back through the `String` type):

    ![compass-919-add-still-loses-date-type](https://cloud.githubusercontent.com/assets/1217010/24235292/b2ffc238-0ff0-11e7-8892-de518b45a53c.gif)

The 2.1 and 2.2 cases I would logically think are the more common cases as they require only the keyboard rather than keyboard and mouse together and involve removing the bad data first then adding in the good data.

I'd be open to suggestions to handle any of these better though I suspect they are more related to COMPASS-921 (EDIT: Or COMPASS-863 too) and more likely to be in Compass rather than here in `hadron-type-checker`.

Screen captures above were created via `npm link ../hadron-type-checker` into Compass.
