### PR TITLE
COMPASS-3806: create long from string or number based on object type

### DIFF
--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -102,6 +102,28 @@ describe('TypeChecker', function() {
             });
           });
 
+          context('when the int64 is very large', function() {
+            context('when the int is larger than max js number', function() {
+              // js max safe integer is 9007199254740991
+              var value = '9007199254740991238';
+
+              it('returns int64', function() {
+                expect(TypeChecker.cast(value, 'Int64')).to.deep.equal(Long.fromString('9007199254740991238'));
+              });
+            });
+
+            context('when the int is larger than max int64 number', function() {
+              // max int64 number is 9223372036854775807
+              var value = '10223372036854775810';
+
+              it('raises an error', function() {
+                expect(function() {
+                  TypeChecker.cast(value, 'Int64');
+                }).to.throw('Value 10223372036854775810 is outside the valid Int64 range');
+              });
+            });
+          });
+
           context('when the int64 is partially valid', function() {
             context('when the int is a -', function() {
               var value = '-';
@@ -330,8 +352,16 @@ describe('TypeChecker', function() {
       });
 
       context('when casting to an int64', function() {
-        it('returns the number as an int64', function() {
+        it('returns the number as an int64 from int32', function() {
           expect(TypeChecker.cast(new Int32(245), 'Int64')).to.deep.equal(new Long(245));
+        });
+
+        it('returns the number as an int64 from decimal', function() {
+          expect(TypeChecker.cast(Decimal128.fromString('245'), 'Int64')).to.deep.equal(new Long(245));
+        });
+
+        it('returns the number as an int64 from double', function() {
+          expect(TypeChecker.cast(new Double('245'), 'Int64')).to.deep.equal(new Long(245));
         });
       });
 
@@ -344,6 +374,14 @@ describe('TypeChecker', function() {
       context('when casting to decimal-128', function() {
         it('returns the number as decimal-128', function() {
           expect(TypeChecker.cast(new Int32(245), 'Decimal128').toString()).to.equal('245');
+        });
+      });
+    });
+
+    context('when the object is an int64', function() {
+      context('when casting to an int64', function() {
+        it('returns the number as an int64', function() {
+          expect(TypeChecker.cast(new Long(245), 'Int64')).to.deep.equal(new Long(245));
         });
       });
     });


### PR DESCRIPTION
## Description
A bit more logic around casting to Int64:
- when casting from a number like int32 (literal or object) create Long from a
  number
- when casting from an object like another int64 object, create a string from
  the object first, and then create long from string
- when casting from a string, create long from string.

### Checklist
- [x] New tests and/or benchmarks are included
~- [ ] Documentation is changed or added~

## Dependents
This will require a pull with updated version of this package to compass-crud to
take full effect.

## Types of changes
- [x] Minor (non-breaking change which adds functionality)